### PR TITLE
Add Prowlarr to supported addons list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ It currently supports:
 - Torbox Addon
 - Debridio
 - Jackettio
+- Prowlarr: requires your Prowlarr URL and API key. Configure `PROWLARR_URL`, `PROWLARR_API_KEY` and optionally `DEFAULT_PROWLARR_TIMEOUT`.
 - Peerflix
 - DMM Cast
 - Orion Stremio Addon


### PR DESCRIPTION
## Summary
- document Prowlarr as a supported addon

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f77b97c4832997f332113af85060