### PR TITLE
Add Prowlarr wrapper

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -126,6 +126,11 @@ EASYNEWS_PLUS_URL=https://b89262c192b0-stremio-easynews-addon.baby-beamup.club/
 DEFAULT_EASYNEWS_PLUS_TIMEOUT=
 # -------------------------------------
 
+# ----------- PROWLARR --------
+PROWLARR_URL=https://prowlarr.example.com/
+DEFAULT_PROWLARR_TIMEOUT=
+# -------------------------------------
+
 # ----------- TORRENTIO -------------
 TORRENTIO_URL=https://torrentio.strem.fun/
 DEFAULT_TORRENTIO_TIMEOUT=

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ It currently supports:
 - Orion Stremio Addon
 - Easynews
 - Easynews+
+- Prowlarr
 - [Stremio GDrive](https://github.com/Viren070/stremio-gdrive-addon)
 - Custom: You can input an addon URL and name and it will parse as much information as it can.
 

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -10,6 +10,7 @@ import {
   getOrionStreams,
   getPeerflixStreams,
   getStremioJackettStreams,
+  getProwlarrStreams,
   getTorboxStreams,
   getTorrentioStreams,
 } from '@aiostreams/wrappers';
@@ -1090,6 +1091,14 @@ export class AIOStreams {
       }
       case 'peerflix': {
         return await getPeerflixStreams(
+          this.config,
+          addon.options,
+          streamRequest,
+          addonId
+        );
+      }
+      case 'prowlarr': {
+        return await getProwlarrStreams(
           this.config,
           addon.options,
           streamRequest,

--- a/packages/utils/src/details.ts
+++ b/packages/utils/src/details.ts
@@ -496,6 +496,24 @@ export const addonDetails: AddonDetail[] = [
     ],
   },
   {
+    name: 'Prowlarr',
+    id: 'prowlarr',
+    requiresService: false,
+    supportedServices: ['realdebrid', 'alldebrid', 'premiumize', 'debridlink', 'torbox'],
+    options: [
+      { id: 'prowlarrUrl', label: 'Prowlarr URL', type: 'text', secret: true, required: true },
+      { id: 'apiKey', label: 'API Key', type: 'text', secret: true, required: true },
+      { id: 'overrideName', label: 'Override Addon Name', type: 'text', required: false },
+      {
+        id: 'indexerTimeout',
+        label: 'Override Indexer Timeout',
+        type: 'number',
+        required: false,
+        constraints: { min: Settings.MIN_TIMEOUT, max: Settings.MAX_TIMEOUT },
+      },
+    ],
+  },
+  {
     name: 'Orion Stremio Addon',
     id: 'orion-stremio-addon',
     requiresService: false,

--- a/packages/utils/src/settings.ts
+++ b/packages/utils/src/settings.ts
@@ -206,6 +206,13 @@ export class Settings {
     ? parseInt(process.env.DEFAULT_EASYNEWS_PLUS_TIMEMOUT)
     : undefined;
 
+  public static readonly PROWLARR_URL =
+    process.env.PROWLARR_URL || 'https://prowlarr.example.com';
+  public static readonly DEFAULT_PROWLARR_TIMEOUT = process.env
+    .DEFAULT_PROWLARR_TIMEOUT
+    ? parseInt(process.env.DEFAULT_PROWLARR_TIMEOUT)
+    : undefined;
+
   public static readonly DEBRIDIO_URL =
     process.env.DEBRIDIO_URL || 'https://debridio.adobotec.com/';
   public static readonly DEFAULT_DEBRIDIO_TIMEOUT = process.env

--- a/packages/wrappers/src/index.ts
+++ b/packages/wrappers/src/index.ts
@@ -11,3 +11,4 @@ export * from './orion';
 export * from './peerflix';
 export * from './dmmCast';
 export * from './stremio-jackett';
+export * from './prowlarr';

--- a/packages/wrappers/src/prowlarr.ts
+++ b/packages/wrappers/src/prowlarr.ts
@@ -1,0 +1,112 @@
+import { StreamRequest, Stream, ParsedStream, Config } from '@aiostreams/types';
+import { BaseWrapper } from './base';
+import { createLogger, Settings } from '@aiostreams/utils';
+import { ProxyAgent, fetch as uFetch } from 'undici';
+
+const logger = createLogger('wrappers');
+
+interface ProwlarrRelease {
+  title?: string;
+  magnetUrl?: string;
+  downloadUrl?: string;
+  infoHash?: string;
+  size?: number;
+  seeders?: number;
+  indexer?: string;
+}
+
+export class Prowlarr extends BaseWrapper {
+  private apiKey: string;
+  constructor(
+    apiKey: string,
+    overrideUrl: string | null,
+    addonName: string = 'Prowlarr',
+    addonId: string,
+    userConfig: Config,
+    indexerTimeout?: number
+  ) {
+    super(
+      addonName,
+      overrideUrl ? overrideUrl.replace(/\/$/, '') : Settings.PROWLARR_URL.replace(/\/$/, ''),
+      addonId,
+      userConfig,
+      indexerTimeout || Settings.DEFAULT_PROWLARR_TIMEOUT
+    );
+    this.apiKey = apiKey;
+  }
+
+  protected standardizeManifestUrl(url: string): string {
+    return url.replace(/\/$/, '');
+  }
+
+  protected async getStreams(streamRequest: StreamRequest): Promise<Stream[]> {
+    const urlObj = new URL('/api/v1/search', this.addonUrl + '/');
+    urlObj.searchParams.set('query', streamRequest.id);
+    urlObj.searchParams.set('limit', '100');
+
+    const headers = new Headers();
+    headers.set('X-Api-Key', this.apiKey);
+    const userIp = this.userConfig.requestingIp;
+    if (userIp) {
+      headers.set('X-Client-IP', userIp);
+      headers.set('X-Forwarded-For', userIp);
+      headers.set('X-Real-IP', userIp);
+    }
+
+    const url = urlObj.toString();
+    const useProxy = this.shouldProxyRequest(url);
+    const sanitisedUrl = this.getLoggableUrl(url);
+    logger.info(`Making a ${useProxy ? 'proxied' : 'direct'} request to Prowlarr (${sanitisedUrl})`);
+
+    const response = await (useProxy
+      ? uFetch(url, {
+          dispatcher: new ProxyAgent(Settings.ADDON_PROXY),
+          method: 'GET',
+          headers,
+          signal: AbortSignal.timeout(this.indexerTimeout),
+        })
+      : fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(this.indexerTimeout) }));
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`${response.status} - ${response.statusText} ${text}`);
+    }
+    const releases: ProwlarrRelease[] = await response.json();
+    return releases.map((rel) => {
+      const stream: Stream = {
+        url: rel.magnetUrl || rel.downloadUrl,
+        infoHash: rel.infoHash || undefined,
+        name: rel.title,
+        description: `${rel.title ?? ''}\n🌐 ${rel.indexer ?? ''}${rel.seeders ? `\n👥 ${rel.seeders}` : ''}`,
+        behaviorHints: { filename: rel.title, videoSize: rel.size },
+      };
+      return stream;
+    });
+  }
+}
+
+export async function getProwlarrStreams(
+  config: Config,
+  prowlarrOptions: {
+    prowlarrUrl?: string;
+    apiKey: string;
+    overrideName?: string;
+    indexerTimeout?: string;
+  },
+  streamRequest: StreamRequest,
+  addonId: string
+): Promise<{ addonStreams: ParsedStream[]; addonErrors: string[] }> {
+  if (!prowlarrOptions.apiKey) {
+    throw new Error('Missing API key for Prowlarr');
+  }
+  const prowlarr = new Prowlarr(
+    prowlarrOptions.apiKey,
+    prowlarrOptions.prowlarrUrl ?? null,
+    prowlarrOptions.overrideName,
+    addonId,
+    config,
+    prowlarrOptions.indexerTimeout ? parseInt(prowlarrOptions.indexerTimeout) : undefined
+  );
+  return prowlarr.getParsedStreams(streamRequest);
+}
+


### PR DESCRIPTION
## Summary
- implement new `Prowlarr` wrapper for searching Prowlarr
- expose wrapper from wrappers package and integrate in addon switch logic
- describe new addon in details list and README
- allow configuring Prowlarr URL and timeout in settings
- document new env variables

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f480d0408329b26f7f867f0e97ec